### PR TITLE
moves event binding to Table to prevent unbind error

### DIFF
--- a/dist/Table/index.js
+++ b/dist/Table/index.js
@@ -41,6 +41,18 @@
     return target;
   };
 
+  function _objectWithoutProperties(obj, keys) {
+    var target = {};
+
+    for (var i in obj) {
+      if (keys.indexOf(i) >= 0) continue;
+      if (!Object.prototype.hasOwnProperty.call(obj, i)) continue;
+      target[i] = obj[i];
+    }
+
+    return target;
+  }
+
   function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
       throw new TypeError("Cannot call a class as a function");
@@ -99,11 +111,29 @@
     }
 
     _createClass(Table, [{
+      key: 'componentDidMount',
+      value: function componentDidMount() {
+        this.table.addEventListener('resize', this.props.onResize);
+      }
+    }, {
+      key: 'componentWillUnmount',
+      value: function componentWillUnmount() {
+        this.table.removeEventListener('resize', this.props.onResize);
+      }
+    }, {
       key: 'render',
       value: function render() {
+        var _this2 = this;
+
+        var _props = this.props,
+            onResize = _props.onResize,
+            props = _objectWithoutProperties(_props, ['onResize']);
+
         return _react2.default.createElement(
           'div',
-          _extends({}, this.props, { className: 'sticky-table-container ' + (this.props.className || '') }),
+          _extends({}, props, { className: 'sticky-table-container ' + (this.props.className || ''), ref: function ref(table) {
+              _this2.table = table;
+            } }),
           this.props.children
         );
       }
@@ -113,4 +143,9 @@
   }(_react.Component);
 
   exports.default = Table;
+
+
+  Table.defaultProps = {
+    onResize: function onResize() {}
+  };
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -215,8 +215,6 @@
           this.stickyCorner = this.table.querySelector('#sticky-table-corner');
           this.setScrollData();
 
-          elementResizeEvent(this.realTable, this.onResize);
-
           this.onResize();
           setTimeout(this.onResize);
           this.addScrollBarEventHandlers();
@@ -237,8 +235,6 @@
 
           this.yWrapper.removeEventListener('scroll', this.scrollYScrollbar);
           this.yScrollbar.removeEventListener('scroll', this.onScrollBarY);
-
-          elementResizeEvent.unbind(this.realTable);
         }
       }
     }, {
@@ -473,7 +469,7 @@
               { className: 'sticky-table-x-wrapper', id: 'sticky-table-x-wrapper' },
               _react2.default.createElement(
                 _Table2.default,
-                null,
+                { onResize: this.onResize },
                 rows
               )
             )

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -1,12 +1,30 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 
 export default class Table extends Component {
+
+  componentDidMount() {
+    this.table.addEventListener('resize', this.props.onResize);
+  }
+
+  componentWillUnmount() {
+    this.table.removeEventListener('resize', this.props.onResize);
+  }
+
   render() {
+    const {onResize, ...props} = this.props;
+
     return (
-      <div {...this.props} className={'sticky-table-container ' + (this.props.className || '')}>
+      <div {...props} className={'sticky-table-container ' + (this.props.className || '')} ref={(table) => {
+        this.table = table;
+      }}>
         {this.props.children}
       </div>
     );
   }
 }
+
+Table.defaultProps = {
+  onResize: () => {
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -57,8 +57,6 @@ class StickyTable extends PureComponent {
       this.stickyCorner = this.table.querySelector('#sticky-table-corner');
       this.setScrollData();
 
-      elementResizeEvent(this.realTable, this.onResize);
-
       this.onResize();
       setTimeout(this.onResize);
       this.addScrollBarEventHandlers();
@@ -78,7 +76,6 @@ class StickyTable extends PureComponent {
       this.yWrapper.removeEventListener('scroll', this.scrollYScrollbar);
       this.yScrollbar.removeEventListener('scroll', this.onScrollBarY);
 
-      elementResizeEvent.unbind(this.realTable);
     }
   }
 
@@ -435,7 +432,7 @@ class StickyTable extends PureComponent {
             <Table>{stickyColumn}</Table>
           </div>
           <div className='sticky-table-x-wrapper' id='sticky-table-x-wrapper'>
-            <Table>{rows}</Table>
+            <Table onResize={this.onResize}>{rows}</Table>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Currently the unbinding of the ''realTable'' fails and causes an error. By the time componentWillUnmount is called the element doesn't exist anymore.

With this fix the event binding happens in Table-Component, with an option to pass an event-handler to table. 
Tests + lint ran fine

This fix shouldn't contain breaking changes.

Fix was developed by me and @tleh