### PR TITLE
fix scrollbars overlapping and vertical scrollbar top position

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -315,7 +315,7 @@
     }, {
       key: 'setScrollBarDims',
       value: function setScrollBarDims() {
-        var width = this.getNodeSize(this.dom.bodyTable.firstChild).width + this.dom.stickyColumn.offsetWidth;
+        var width = this.getNodeSize(this.dom.bodyTable.firstChild).width + this.dom.stickyColumn.offsetWidth + this.dom.yScrollbar.offsetWidth - this.dom.yScrollbar.clientWidth;
         this.dom.xScrollbar.firstChild.style.width = width + 'px';
 
         this.xScrollSize = this.dom.xScrollbar.offsetHeight - this.dom.xScrollbar.clientHeight;

--- a/dist/index.js
+++ b/dist/index.js
@@ -309,8 +309,8 @@
     }, {
       key: 'setScrollBarWrapperDims',
       value: function setScrollBarWrapperDims() {
-        this.dom.yScrollbar.style.height = 'calc(100% - ' + this.dom.stickyHeader.offsetHeight + 'px)';
-        this.dom.yScrollbar.style.top = this.dom.stickyHeader.offsetHeight + 'px';
+        this.dom.yScrollbar.style.height = 'calc(100% - ' + this.xScrollSize + 'px)';
+        this.dom.yScrollbar.style.top = 0;
       }
     }, {
       key: 'setScrollBarDims',

--- a/src/index.js
+++ b/src/index.js
@@ -261,7 +261,8 @@ class StickyTable extends PureComponent {
    * @returns {undefined}
    */
   setScrollBarDims() {
-    var width = this.getNodeSize(this.dom.bodyTable.firstChild).width + this.dom.stickyColumn.offsetWidth;
+    var width = this.getNodeSize(this.dom.bodyTable.firstChild).width + this.dom.stickyColumn.offsetWidth
+      + this.dom.yScrollbar.offsetWidth - this.dom.yScrollbar.clientWidth;
     this.dom.xScrollbar.firstChild.style.width = width + 'px';
 
     this.xScrollSize = this.dom.xScrollbar.offsetHeight - this.dom.xScrollbar.clientHeight;

--- a/src/index.js
+++ b/src/index.js
@@ -252,8 +252,8 @@ class StickyTable extends PureComponent {
    * @returns {undefined}
    */
   setScrollBarWrapperDims() {
-    this.dom.yScrollbar.style.height = 'calc(100% - ' + this.dom.stickyHeader.offsetHeight + 'px)';
-    this.dom.yScrollbar.style.top = this.dom.stickyHeader.offsetHeight + 'px';
+    this.dom.yScrollbar.style.height = 'calc(100% - ' + this.xScrollSize  + 'px)';
+    this.dom.yScrollbar.style.top = 0;
   }
 
   /**


### PR DESCRIPTION
When vertical scrollbar has top margin there is a gap in top right corner of table. Moving vertical scrollbar top edge to top of table and vertical scrollbar bottom edge above horizontal scroll bar makes UI better looking.