### PR TITLE
Fix y-scrollbar behavior when rows are fixed.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -337,7 +337,7 @@
       value: function setRowHeights() {
         var _this3 = this;
 
-        var bodyRows, stickyHeaderRows, stickyCornerRows, stickyColumnRows, cells, columnHeight, resizeRow, row;
+        var bodyRows, stickyHeaderRows, stickyCornerRows, stickyColumnRows, cells, columnHeight, resizeRow;
 
         if (this.rowCount > 0 && this.props.stickyColumnCount > 0) {
           bodyRows = this.dom.bodyTable.childNodes;
@@ -350,11 +350,11 @@
             cells = [];
 
             if (row < _this3.props.stickyHeaderCount) {
-              //It's a sticky column
+              //It's a sticky row
               cells[0] = stickyCornerRows[row].childNodes[0];
               cells[1] = stickyHeaderRows[row].childNodes[0];
             } else {
-              //It's a body column
+              //It's a body row
               cells[0] = stickyColumnRows[row - _this3.props.stickyHeaderCount].childNodes[0];
               cells[1] = bodyRows[row - _this3.props.stickyHeaderCount].childNodes[0];
             }
@@ -370,10 +370,14 @@
             });
           };
 
-          for (row = 0; row < this.rowCount; row++) {
+          var _loop = function _loop(row) {
             setTimeout(function () {
               return resizeRow(row);
             });
+          };
+
+          for (var row = 0; row < this.rowCount; row++) {
+            _loop(row);
           }
         }
       }
@@ -382,7 +386,7 @@
       value: function setColumnWidths() {
         var _this4 = this;
 
-        var firstBodyRowCells, firstStickyHeaderRowCells, firstStickyCornerRowCells, firstStickyColumnRowCells, cells, resizeColumn, column;
+        var firstBodyRowCells, firstStickyHeaderRowCells, firstStickyCornerRowCells, firstStickyColumnRowCells, cells, resizeColumn;
 
         if (this.columnCount > 0 && this.props.stickyHeaderCount > 0) {
           firstBodyRowCells = this.dom.bodyTable.childNodes[0].childNodes;
@@ -417,10 +421,14 @@
             });
           };
 
-          for (column = 0; column < this.columnCount; column++) {
+          var _loop2 = function _loop2(column) {
             setTimeout(function () {
               return resizeColumn(column);
             });
+          };
+
+          for (var column = 0; column < this.columnCount; column++) {
+            _loop2(column);
           }
         }
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -371,7 +371,9 @@
           };
 
           for (row = 0; row < this.rowCount; row++) {
-            setTimeout(resizeRow(row));
+            setTimeout(function () {
+              return resizeRow(row);
+            });
           }
         }
       }
@@ -416,7 +418,9 @@
           };
 
           for (column = 0; column < this.columnCount; column++) {
-            setTimeout(resizeColumn(column));
+            setTimeout(function () {
+              return resizeColumn(column);
+            });
           }
         }
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -320,7 +320,7 @@
 
         this.xScrollSize = this.dom.xScrollbar.offsetHeight - this.dom.xScrollbar.clientHeight;
 
-        var height = this.dom.bodyTable.offsetHeight + this.dom.stickyHeader.offsetHeight;
+        var height = this.dom.bodyTable.offsetHeight;
         this.dom.yScrollbar.firstChild.style.height = height + 'px';
 
         this.yScrollSize = this.dom.yScrollbar.offsetWidth - this.dom.yScrollbar.clientWidth;

--- a/src/index.js
+++ b/src/index.js
@@ -266,7 +266,7 @@ class StickyTable extends PureComponent {
 
     this.xScrollSize = this.dom.xScrollbar.offsetHeight - this.dom.xScrollbar.clientHeight;
 
-    var height = this.dom.bodyTable.offsetHeight + this.dom.stickyHeader.offsetHeight;
+    var height = this.dom.bodyTable.offsetHeight;
     this.dom.yScrollbar.firstChild.style.height = height + 'px';
 
     this.yScrollSize = this.dom.yScrollbar.offsetWidth - this.dom.yScrollbar.clientWidth;

--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ class StickyTable extends PureComponent {
    * @returns {undefined}
    */
   setRowHeights() {
-    var bodyRows, stickyHeaderRows, stickyCornerRows, stickyColumnRows, cells, columnHeight, resizeRow, row;
+    var bodyRows, stickyHeaderRows, stickyCornerRows, stickyColumnRows, cells, columnHeight, resizeRow;
 
     if (this.rowCount > 0 && this.props.stickyColumnCount > 0) {
       bodyRows = this.dom.bodyTable.childNodes;
@@ -293,13 +293,13 @@ class StickyTable extends PureComponent {
       stickyCornerRows = this.dom.stickyCornerTable.childNodes;
       stickyHeaderRows = this.dom.stickyHeaderTable.childNodes;
 
-      resizeRow = row => {
+      resizeRow = (row) => {
         cells = [];
 
-        if (row < this.props.stickyHeaderCount) { //It's a sticky column
+        if (row < this.props.stickyHeaderCount) { //It's a sticky row
           cells[0] = stickyCornerRows[row].childNodes[0];
           cells[1] = stickyHeaderRows[row].childNodes[0];
-        } else { //It's a body column
+        } else { //It's a body row
           cells[0] = stickyColumnRows[row - this.props.stickyHeaderCount].childNodes[0];
           cells[1] = bodyRows[row - this.props.stickyHeaderCount].childNodes[0];
         }
@@ -311,7 +311,7 @@ class StickyTable extends PureComponent {
         cells.forEach(cell => cell.style.height = `${Math.round(columnHeight)}px`);
       };
 
-      for (row = 0; row < this.rowCount; row++) {
+      for (let row = 0; row < this.rowCount; row++) {
         setTimeout(() => resizeRow(row));
       }
     }
@@ -323,7 +323,7 @@ class StickyTable extends PureComponent {
    */
   setColumnWidths() {
     var firstBodyRowCells, firstStickyHeaderRowCells, firstStickyCornerRowCells, firstStickyColumnRowCells,
-      cells, resizeColumn, column;
+      cells, resizeColumn;
 
     if (this.columnCount > 0 && this.props.stickyHeaderCount > 0) {
       firstBodyRowCells = this.dom.bodyTable.childNodes[0].childNodes;
@@ -352,7 +352,7 @@ class StickyTable extends PureComponent {
         cells.forEach(cell => cell.style.width = cell.style.minWidth = `${columnWidth}px`);
       };
 
-      for (column = 0; column < this.columnCount; column++) {
+      for (let column = 0; column < this.columnCount; column++) {
         setTimeout(() => resizeColumn(column));
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,7 @@ class StickyTable extends PureComponent {
       };
 
       for (row = 0; row < this.rowCount; row++) {
-        setTimeout(resizeRow(row));
+        setTimeout(() => resizeRow(row));
       }
     }
   }
@@ -353,7 +353,7 @@ class StickyTable extends PureComponent {
       };
 
       for (column = 0; column < this.columnCount; column++) {
-        setTimeout(resizeColumn(column));
+        setTimeout(() => resizeColumn(column));
       }
     }
   }


### PR DESCRIPTION
The scrollbar wasn't going all the way down as mentioned in #47 and #46.
I've also fixed an issue that appeared at 4 tests. Parameter for setTimeout should be callable.