### PR TITLE
Fix main and module lines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "react-sticky-table",
-  "version": "2.0.4",
-  "main": "index.js",
-  "module": "./index.js",
+  "version": "2.0.5",
+  "main": "dist/index.js",
+  "source": "src/index.js",
   "description": "Dynamically sized fixed header and columns for tables",
   "repository": {
     "type": "git",
@@ -64,8 +64,8 @@
     "sinon": "^1.17.3"
   },
   "peerDependencies": {
+    "prop-types": "^15.5.7",
     "react": "^15.0.0",
-    "react-dom": " ^15.0.0",
-    "prop-types": "^15.5.7"
+    "react-dom": " ^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sticky-table",
-  "version": "2.0.5",
+  "version": "2.0.4",
   "main": "dist/index.js",
   "source": "src/index.js",
   "description": "Dynamically sized fixed header and columns for tables",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sticky-table",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "main": "dist/index.js",
   "source": "src/index.js",
   "description": "Dynamically sized fixed header and columns for tables",


### PR DESCRIPTION
I don't think the module attribute in package.json is correct :thinking: With it I'm unable to bundle this with Rollup, getting the following error

```
5: import { StickyTable, Row, Cell } from "react-sticky-table"
            ^
6: import "react-sticky-table/dist/react-sticky-table.css"
Error: 'StickyTable' is not exported by node_modules/react-sticky-table/dist/index.js
```

Removing module resolved this, I've added a source attribute as well