### PR TITLE
Update README example section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ npm install react-sticky-table --save
 import React, { Component } from 'react';
 
 import { StickyTable, Row, Cell } from 'react-sticky-table';
-import 'react-sticky-table/dist/react-sticky-table.css';
 
 export default class BasicExample extends Component {
   render() {


### PR DESCRIPTION
Now are using CSS-in-JS, we don't need to import another css file.