### PR TITLE
Cell needs to be defined before Row

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,18 +11,6 @@ const Table = styled('div').attrs({
 
 Table.displayName = 'Table';
 
-const Row = styled('div').attrs({
-  className: 'sticky-table-row'
-})`
-  display: table-row;
-
-  & ${Cell}:first-child {
-    border-right: 2px solid #e5e5e5;
-  }
-`;
-
-Row.displayName = 'Row';
-
 const Cell = styled('div').attrs({
   className: 'sticky-table-cell'
 })`
@@ -35,6 +23,18 @@ const Cell = styled('div').attrs({
 `;
 
 Cell.displayName = 'Cell';
+
+const Row = styled('div').attrs({
+  className: 'sticky-table-row'
+})`
+  display: table-row;
+
+  & ${Cell}:first-child {
+    border-right: 2px solid #e5e5e5;
+  }
+`;
+
+Row.displayName = 'Row';
 
 const Wrapper = styled('div').attrs({
   className: 'sticky-table'


### PR DESCRIPTION
Since Row's styles reference ${Cell} Cell needs to be defined first

Otherwise the css the gets generated is :

```
.eUqSiS :first-child {
    border-right: 2px solid #e5e5e5;
}
``` 

notice there is no class selector before :first-child and therefore this matches every first child recursively

when patched it looks like this

```
.ldwQkG .sc-bwzfXH:first-child{
    border-right:2px solid #e5e5e5;
}
```