### PR TITLE
Forward wrapperRef to <Wrapper>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,11 +77,13 @@ Wrapper.displayName = 'Wrapper';
 function StickyTable({
   stickyColumnCount = 1,
   stickyHeaderCount = 1,
+  wrapperRef,
   children,
   ...rest
 }) {
   return (
     <Wrapper
+      ref={wrapperRef}
       stickyColumnCount={stickyColumnCount}
       stickyHeaderCount={stickyHeaderCount}
       {...rest}


### PR DESCRIPTION
Using v2.x I was able to use ref callback to get the wrapper dom node however now since v4 uses functional component this doesn't work.  Instead support the forwarding ref pattern using wrapperRef