### PR TITLE
Update storybook files, move playground

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,1 +1,0 @@
-import '@storybook/addon-knobs/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,9 +1,0 @@
-import { configure } from '@storybook/react';
-
-// automatically import all files ending in *.stories.js
-const req = require.context('../stories', true, /\.stories\.js$/);
-function loadStories() {
-  req.keys().forEach(filename => req(filename));
-}
-
-configure(loadStories, module);

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+  stories: ['../stories/**/*.stories.js'],
+  addons: ['@storybook/addon-knobs']
+  };

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,11 @@
+import { addons } from '@storybook/addons';
+import { create } from '@storybook/theming/create';
+import { version } from '../package.json';
+
+addons.setConfig({
+  panelPosition: 'bottom',
+  theme: create({
+    base: 'light',
+    brandTitle: `react-sticky-table@${version}`
+  })
+});

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -28,8 +28,10 @@ storiesOf('Basic', module)
   .add('custom borders', () => <Borders />)
   .add('no borders', () => <NoBorders />)
   .add('custom z-index', () => <CustomZ />)
+
+storiesOf('Playground')
   .addDecorator(withKnobs)
-  .add('playground', () => <Playground
+  .add('sticky tests', () => <Playground
     stickyHeaderCount={number('HeaderSticky', 0, { min: 0 })}
     leftStickyColumnCount={number('LeftSticky', 0, { min: 0 })}
     rightStickyColumnCount={number('RightSticky', 0, { min: 0 })}


### PR DESCRIPTION
Following a minor comment about _where is this knobs panel_...

Moving around the storybook related files so they are in line with their new standars which are alos used in storybook@6, so it can be upgraded with no breaking changes when it drops.
Added `react-sticky-table@version` ath the header of the storybook, set the knobs panel to be shown always (on first load, subsequent changes get stored on `localStorage` by  storybook)
Moved playground to be differentiated from premade exampes.