### PR TITLE
Fix invalid version string in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "prop-types": "^15.5.7",
     "react": ">=16.0.0",
-    "react-dom": " ^16.0.0"
+    "react-dom": "^16.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix invalid version string

npm ERR! Could not resolve dependency:
npm ERR! peer react-dom@" ^16.0.0" from react-sticky-table@5.1.11
npm ERR! node_modules/react-sticky-table
npm ERR!   react-sticky-table@"^5.1.11" from the root project